### PR TITLE
Read VDS; no need for data file

### DIFF
--- a/baseline/h5read.c
+++ b/baseline/h5read.c
@@ -1,4 +1,5 @@
 #include <hdf5.h>
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -11,13 +12,34 @@ uint8_t *mask;
 uint8_t *module_mask;
 size_t mask_size;
 
+// VDS stuff
+
+#define MAXFILENAME 256
+#define MAXDATAFILES 100
+#define MAXDIM 3
+
+typedef struct h5_data_file {
+    char filename[MAXFILENAME];
+    char dsetname[MAXFILENAME];
+    hid_t file;
+    hid_t dataset;
+    size_t frames;
+    size_t offset;
+} h5_data_file;
+
+// allocate space for 100 virtual files (which would mean 100,000 frames)
+
+h5_data_file data_files[MAXDATAFILES];
+int data_file_count;
+int data_file_current;
+
 hid_t master;
-hid_t data;
-hid_t dataset;
 
 void cleanup_hdf5() {
-    H5Dclose(dataset);
-    H5Fclose(data);
+    for (int i = 0; i < data_file_count; i++) {
+        H5Dclose(data_files[i].dataset);
+        H5Fclose(data_files[i].file);
+    }
     H5Fclose(master);
     free(mask);
     free(module_mask);
@@ -96,10 +118,30 @@ void free_image_modules(image_modules_t i) {
 }
 
 image_t get_image(size_t n) {
+    int data_file;
+
+    h5_data_file *current;
+
     if (n >= frames) {
         fprintf(stderr, "image %ld > frames (%ld)\n", n, frames);
         exit(1);
     }
+
+    /* first find the right data file - having to do this lookup is annoying
+       but probably cheap */
+
+    for (data_file = 0; data_file < data_file_count; data_file++) {
+        if (n >= data_files[data_file].offset) {
+            break;
+        }
+    }
+
+    if (data_file == data_file_count) {
+        fprintf(stderr, "could not find data file for frame %ld\n", n);
+        exit(1);
+    }
+
+    current = &(data_files[data_file]);
 
     hid_t mem_space, space, datatype;
 
@@ -111,18 +153,19 @@ image_t get_image(size_t n) {
     block[1] = slow;
     block[2] = fast;
 
-    offset[0] = n;
+    offset[0] = n - current->offset;
     offset[1] = 0;
     offset[2] = 0;
 
-    space = H5Dget_space(dataset);
-    datatype = H5Dget_type(dataset);
+    space = H5Dget_space(current->dataset);
+    datatype = H5Dget_type(current->dataset);
 
     // select data to read #todo add status checks
     H5Sselect_hyperslab(space, H5S_SELECT_SET, offset, NULL, block, NULL);
     mem_space = H5Screate_simple(3, block, NULL);
 
-    if (H5Dread(dataset, datatype, mem_space, space, H5P_DEFAULT, buffer) < 0) {
+    if (H5Dread(current->dataset, datatype, mem_space, space, H5P_DEFAULT, buffer)
+        < 0) {
         H5Eprint(H5E_DEFAULT, NULL);
         exit(1);
     }
@@ -258,21 +301,136 @@ void read_mask() {
     H5Dclose(mask_dataset);
 }
 
+int vds_info(char *root, hid_t master, hid_t dataset, h5_data_file *vds) {
+    hid_t plist, vds_source;
+    size_t vds_count;
+    herr_t status;
+
+    plist = H5Dget_create_plist(dataset);
+
+    status = H5Pget_virtual_count(plist, &vds_count);
+
+    for (int j = 0; j < vds_count; j++) {
+        hsize_t start[MAXDIM], stride[MAXDIM], count[MAXDIM], block[MAXDIM];
+        size_t dims;
+
+        vds_source = H5Pget_virtual_vspace(plist, j);
+        dims = H5Sget_simple_extent_ndims(vds_source);
+
+        if (dims != 3) {
+            H5Sclose(vds_source);
+            fprintf(stderr, "incorrect data dimensionality: %d\n", (int)dims);
+            return -1;
+        }
+
+        H5Sget_regular_hyperslab(vds_source, start, stride, count, block);
+        H5Sclose(vds_source);
+
+        H5Pget_virtual_filename(plist, j, vds[j].filename, MAXFILENAME);
+        H5Pget_virtual_dsetname(plist, j, vds[j].dsetname, MAXFILENAME);
+
+        for (int k = 1; k < dims; k++) {
+            if (start[k] != 0) {
+                fprintf(stderr, "incorrect chunk start: %d\n", (int)start[k]);
+                return -1;
+            }
+        }
+
+        vds[j].frames = block[0];
+        vds[j].offset = start[0];
+
+        if ((strlen(vds[j].filename) == 1) && (vds[j].filename[0] == '.')) {
+            H5L_info_t info;
+            status = H5Lget_info(master, vds[j].dsetname, &info, H5P_DEFAULT);
+
+            if (status) {
+                fprintf(stderr, "error from H5Lget_info on %s\n", vds[j].dsetname);
+                return -1;
+            }
+
+            /* if the data file points to an external source, dereference */
+
+            if (info.type == H5L_TYPE_EXTERNAL) {
+                char buffer[MAXFILENAME], scr[MAXFILENAME];
+                unsigned flags;
+                const char *nameptr, *dsetptr;
+
+                H5Lget_val(master, vds[j].dsetname, buffer, MAXFILENAME, H5P_DEFAULT);
+                H5Lunpack_elink_val(
+                  buffer, info.u.val_size, &flags, &nameptr, &dsetptr);
+
+                /* assumptions herein:
+                    - external link references are local paths
+                    - only need to worry about UNIX paths e.g. pathsep is /
+                    - ASCII so chars are ... chars
+                   so manually assemble...
+                 */
+
+                strcpy(scr, root);
+                scr[strlen(root)] = '/';
+                strcpy(scr + strlen(root) + 1, nameptr);
+
+                strcpy(vds[j].filename, scr);
+                strcpy(vds[j].dsetname, dsetptr);
+            }
+        } else {
+            char scr[MAXFILENAME];
+            sprintf(scr, "%s/%s", root, vds[j].filename);
+            strcpy(vds[j].filename, scr);
+        }
+
+        // do I want to open these here? Or when they are needed...
+        vds[j].file = 0;
+        vds[j].dataset = 0;
+    }
+
+    status = H5Pclose(plist);
+
+    return vds_count;
+}
+
+int unpack_vds(char *filename, h5_data_file *data_files) {
+    hid_t dataset, file;
+    char *root, cwd[MAXFILENAME];
+    int retval;
+
+    // TODO if we want this to become SWMR aware in the future will need to
+    // allow for that here
+    file = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+
+    if (file < 0) {
+        fprintf(stderr, "error reading %s\n", filename);
+        return -1;
+    }
+
+    dataset = H5Dopen(file, "/entry/data/data", H5P_DEFAULT);
+
+    if (dataset < 0) {
+        H5Fclose(file);
+        fprintf(stderr, "error reading %s\n", "/entry/data/data");
+        return -1;
+    }
+
+    /* always set the absolute path to file information */
+    root = dirname(filename);
+    if ((strlen(root) == 1) && (root[0] == '.')) {
+        root = getcwd(cwd, MAXFILENAME);
+    }
+
+    retval = vds_info(root, file, dataset, data_files);
+
+    H5Dclose(dataset);
+    H5Fclose(file);
+
+    return retval;
+}
+
 void setup_data() {
-    // uses master pointer above: beware if this is bad
-
-    char data_path[] = "/data";
-
-    hid_t datatype, space;
+    hid_t datatype, space, dataset;
 
     hsize_t dims[3];
 
-    dataset = H5Dopen(data, data_path, H5P_DEFAULT);
-
-    if (dataset < 0) {
-        fprintf(stderr, "error reading data from %s\n", data_path);
-        exit(1);
-    }
+    dataset = data_files[0].dataset;
 
     datatype = H5Dget_type(dataset);
 
@@ -290,38 +448,52 @@ void setup_data() {
 
     H5Sget_simple_extent_dims(space, dims, NULL);
 
-    frames = dims[0];
     slow = dims[1];
     fast = dims[2];
 
     printf("total data size: %ldx%ldx%ld\n", frames, slow, fast);
+    H5Sclose(space);
 }
 
-int setup_hdf5_files(char *master_filename, char *data_filename) {
+int setup_hdf5_files(char *master_filename) {
     /* I'll do my own debug printing: disable HDF5 library output */
     H5Eset_auto(H5E_DEFAULT, NULL, NULL);
 
-    master = H5Fopen(master_filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, H5P_DEFAULT);
+    master = H5Fopen(master_filename, H5F_ACC_RDONLY, H5P_DEFAULT);
 
     if (master < 0) {
         fprintf(stderr, "error reading %s\n", master_filename);
         return 1;
     }
 
-    data = H5Fopen(data_filename, H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, H5P_DEFAULT);
+    data_file_count = unpack_vds(master_filename, data_files);
 
-    if (data < 0) {
-        fprintf(stderr, "error reading %s\n", data_filename);
+    if (data_file_count < 0) {
+        fprintf(stderr, "error reading %s\n", master_filename);
         return 1;
+    }
+
+    // open up the actual data files, count all the frames
+    frames = 0;
+    for (int j = 0; j < data_file_count; j++) {
+        data_files[j].file =
+          H5Fopen(data_files[j].filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+        if (data_files[j].file < 0) {
+            fprintf(stderr, "error reading %s\n", data_files[j].filename);
+            return 1;
+        }
+        data_files[j].dataset =
+          H5Dopen(data_files[j].file, data_files[j].dsetname, H5P_DEFAULT);
+        if (data_files[j].dataset < 0) {
+            fprintf(stderr, "error reading %s\n", data_files[j].filename);
+            return 1;
+        }
+        frames += data_files[j].frames;
     }
 
     read_mask();
 
     setup_data();
-
-    // do stuff
-
-    // cleanup
 
     return 0;
 }

--- a/baseline/h5read.c
+++ b/baseline/h5read.c
@@ -131,7 +131,7 @@ image_t get_image(size_t n) {
        but probably cheap */
 
     for (data_file = 0; data_file < data_file_count; data_file++) {
-        if (n >= data_files[data_file].offset) {
+        if ((n - data_files[data_file].offset) < data_files[data_file].frames) {
             break;
         }
     }

--- a/baseline/miniapp.c
+++ b/baseline/miniapp.c
@@ -4,12 +4,12 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-    if (argc == 2) {
-        fprintf(stderr, "%s foobar.nxs foobar_000001.h5\n", argv[0]);
+    if (argc == 1) {
+        fprintf(stderr, "%s foobar.nxs\n", argv[0]);
         return 1;
     }
 
-    if (setup_hdf5_files(argv[1], argv[2]) < 0) {
+    if (setup_hdf5_files(argv[1]) < 0) {
         fprintf(stderr, "<shrug> bad thing </shrug>\n");
         exit(1);
     }

--- a/baseline/miniapp.h
+++ b/baseline/miniapp.h
@@ -7,7 +7,7 @@
  *
  * Call
  *
- * setup_hdf5_files(master_filename, data_filename)
+ * setup_hdf5_files(master_filename)
  *
  * to initialise all of the HDF5 data structures, read and transform the mask
  * etc. Then
@@ -42,7 +42,7 @@ typedef struct image_modules_t {
 } image_modules_t;
 
 /* set up HDF5 files - call at the start */
-int setup_hdf5_files(char *master_filename, char *data_filename);
+int setup_hdf5_files(char *master_filename);
 
 /* clean up at the end */
 void cleanup_hdf5();


### PR DESCRIPTION
So

```
Grey-Area _build :) [read-vds] $ ./h5read ~/data/miniapp/xrc_93.nxs 
mask dtype uint64mask has 4471016 elements
4210139 of the pixels are valid
total data size: 81x2162x2068
image 0 had 3862935 / 3862935 valid zero pixels
image 1 had 3863427 / 3863427 valid zero pixels
image 2 had 3865052 / 3865052 valid zero pixels
image 3 had 3862059 / 3862059 valid zero pixels
image 4 had 3859526 / 3859526 valid zero pixels
image 5 had 3861462 / 3861462 valid zero pixels
image 6 had 3859382 / 3859382 valid zero pixels
```

et. seq - also means you could work on files with many thousands of images (slowly, because single threads) 