### PR TITLE
Wavelength from header

### DIFF
--- a/cuda/spotfinder/cbfread.hpp
+++ b/cuda/spotfinder/cbfread.hpp
@@ -143,6 +143,9 @@ class CBFRead : public Reader {
     virtual std::array<image_t_type, 2> get_trusted_range() const {
         return {0, std::numeric_limits<image_t_type>::max()};
     }
+    virtual std::optional<float> get_wavelength() const {
+        return std::nullopt;
+    }
 };
 
 template <typename Tout>

--- a/cuda/spotfinder/shmread.cc
+++ b/cuda/spotfinder/shmread.cc
@@ -34,6 +34,12 @@ SHMRead::SHMRead(const std::string &path) : _base_path(path) {
     _trusted_range = {
       0, data["countrate_correction_count_cutoff"].template get<image_t_type>()};
 
+    if (data.contains("wavelength")) {
+        _wavelength = data["wavelength"].template get<float>();
+    } else {
+        _wavelength = std::nullopt;
+    }
+
     // Read the mask
     std::vector<int32_t> raw_mask;
     raw_mask.resize(_image_shape[0] * _image_shape[1]);

--- a/cuda/spotfinder/shmread.hpp
+++ b/cuda/spotfinder/shmread.hpp
@@ -39,7 +39,7 @@ class SHMRead : public Reader {
     virtual std::array<image_t_type, 2> get_trusted_range() const {
         return _trusted_range;
     }
-    std::optional<float> get_wavelength() const override {
+    std::optional<float> get_wavelength() const {
         return _wavelength;
     }
 };

--- a/cuda/spotfinder/shmread.hpp
+++ b/cuda/spotfinder/shmread.hpp
@@ -14,6 +14,7 @@ class SHMRead : public Reader {
     const std::string _base_path;
     std::vector<uint8_t> _mask;
     std::array<image_t_type, 2> _trusted_range;
+    std::optional<float> _wavelength;
 
   public:
     SHMRead(const std::string &path);
@@ -37,6 +38,9 @@ class SHMRead : public Reader {
     }
     virtual std::array<image_t_type, 2> get_trusted_range() const {
         return _trusted_range;
+    }
+    std::optional<float> get_wavelength() const override {
+        return _wavelength;
     }
 };
 

--- a/cuda/spotfinder/spotfinder.cc
+++ b/cuda/spotfinder/spotfinder.cc
@@ -397,7 +397,9 @@ int main(int argc, char **argv) {
     } else {
         auto wavelength_opt = reader.get_wavelength();
         if (!wavelength_opt) {
-            print("Error: No wavelength provided\n");
+            print(
+              "Error: No wavelength provided. Please pass wavelength using: "
+              "--wavelength\n");
             std::exit(1);
         }
         wavelength = wavelength_opt.value();

--- a/cuda/spotfinder/spotfinder.cc
+++ b/cuda/spotfinder/spotfinder.cc
@@ -403,8 +403,6 @@ int main(int argc, char **argv) {
         wavelength = wavelength_opt.value();
     }
 
-    printf("Wavelength: %f\n", wavelength);
-
     std::signal(SIGINT, stop_processing);
 
     // Work out how many blocks this is

--- a/cuda/spotfinder/spotfinder.cc
+++ b/cuda/spotfinder/spotfinder.cc
@@ -403,6 +403,7 @@ int main(int argc, char **argv) {
             std::exit(1);
         }
         wavelength = wavelength_opt.value();
+        printf("Got wavelength from file: %f Å\n", wavelength);
     }
 
     std::signal(SIGINT, stop_processing);

--- a/cuda/spotfinder/spotfinder.cc
+++ b/cuda/spotfinder/spotfinder.cc
@@ -342,7 +342,6 @@ int main(int argc, char **argv) {
 
     float dmin = parser.get<float>("dmin");
     float dmax = parser.get<float>("dmax");
-    float wavelength = parser.get<float>("wavelength");
     std::string detector_json = parser.get<std::string>("detector");
     json detector_json_obj = json::parse(detector_json);
     detector_geometry detector = detector_geometry(detector_json_obj);
@@ -391,6 +390,20 @@ int main(int argc, char **argv) {
     int height = reader.image_shape()[0];
     int width = reader.image_shape()[1];
     auto trusted_px_max = reader.get_trusted_range()[1];
+
+    float wavelength;
+    if (parser.is_used("wavelength")) {
+        wavelength = parser.get<float>("wavelength");
+    } else {
+        auto wavelength_opt = reader.get_wavelength();
+        if (!wavelength_opt) {
+            print("Error: No wavelength provided\n");
+            std::exit(1);
+        }
+        wavelength = wavelength_opt.value();
+    }
+
+    printf("Wavelength: %f\n", wavelength);
 
     std::signal(SIGINT, stop_processing);
 

--- a/cuda/spotfinder/tests/res_comparison.sh
+++ b/cuda/spotfinder/tests/res_comparison.sh
@@ -19,7 +19,6 @@ exec 3> output_file.txt
   --min-spot-size 3 \
   --pipe_fd 3 \
   --dmin 4 \
-  --wavelength 0.976261 \
   --detector "$(cat detector.json)" \
   --threads 1 \
   --images 1

--- a/h5read/include/h5read.h
+++ b/h5read/include/h5read.h
@@ -48,6 +48,8 @@ size_t h5read_get_image_slow(h5read_handle *obj);
 size_t h5read_get_image_fast(h5read_handle *obj);
 /// Get the trusted range for this dataset
 void h5read_get_trusted_range(h5read_handle *obj, image_t_type *min, image_t_type *max);
+/// Get the wavelength for this dataset
+float h5read_get_wavelength(h5read_handle *obj);
 
 /** Borrow a pointer to the image mask.
  *
@@ -234,6 +236,16 @@ class H5Read : public Reader {
         image_t_type min, max;
         h5read_get_trusted_range(_handle.get(), &min, &max);
         return {min, max};
+    }
+    /// Get the wavelength of the X-ray beam
+    virtual std::optional<float> get_wavelength() const {
+        float wavelength = h5read_get_wavelength(_handle.get());
+        if (wavelength == -1) {  // No wavelength provided
+            return std::nullopt;
+        } else {
+            std::optional<float> result = wavelength;
+            return result;
+        }
     }
 
     std::mutex mutex;

--- a/h5read/include/h5read.h
+++ b/h5read/include/h5read.h
@@ -151,9 +151,7 @@ class Reader {
     virtual std::array<image_t_type, 2> get_trusted_range() const = 0;
     virtual std::array<size_t, 2> image_shape() const = 0;
     virtual std::optional<std::span<const uint8_t>> get_mask() const = 0;
-    virtual std::optional<float> get_wavelength() const {
-        return std::nullopt;
-    }
+    virtual std::optional<float> get_wavelength() const = 0;
 };
 
 // Declare a C++ "object" version so we don't have to keep track of allocations

--- a/h5read/include/h5read.h
+++ b/h5read/include/h5read.h
@@ -151,6 +151,9 @@ class Reader {
     virtual std::array<image_t_type, 2> get_trusted_range() const = 0;
     virtual std::array<size_t, 2> image_shape() const = 0;
     virtual std::optional<std::span<const uint8_t>> get_mask() const = 0;
+    virtual std::optional<float> get_wavelength() const {
+        return std::nullopt;
+    }
 };
 
 // Declare a C++ "object" version so we don't have to keep track of allocations


### PR DESCRIPTION
Utilise the information provided in the `start_*` files during live collection in order to address issue #14.

`start_1` contains the wavelength (in Å). We can get this value by default and then only need to use the wavelength argument in order to overwrite.